### PR TITLE
Fix map editor initialization error in storyteller plugin

### DIFF
--- a/src/map/MapView.ts
+++ b/src/map/MapView.ts
@@ -452,17 +452,18 @@ export class MapView {
     this.map.addControl(this.drawControl);
 
     // Handle draw events
-    this.map.on(L.Draw.Event.CREATED, (e: any) => {
+    // Use string literals instead of L.Draw.Event constants for better compatibility
+    this.map.on('draw:created', (e: any) => {
       const layer = e.layer;
       this.drawnItems.addLayer(layer);
       this.onMapChange?.();
     });
 
-    this.map.on(L.Draw.Event.EDITED, () => {
+    this.map.on('draw:edited', () => {
       this.onMapChange?.();
     });
 
-    this.map.on(L.Draw.Event.DELETED, () => {
+    this.map.on('draw:deleted', () => {
       this.onMapChange?.();
     });
   }


### PR DESCRIPTION
Fixed "Cannot read properties of undefined (reading 'Event')" error in setupDrawingControls by replacing L.Draw.Event constants with their string literal equivalents ('draw:created', 'draw:edited', 'draw:deleted').

This provides better compatibility in the Obsidian environment where the L.Draw namespace augmentation may not be reliably available.

Fixes the error at MapView.ts:455 in setupDrawingControls method.