### PR TITLE
Fix data conversion for custom CLA

### DIFF
--- a/src/utils/CalendarConverter.ts
+++ b/src/utils/CalendarConverter.ts
@@ -805,6 +805,7 @@ export class CalendarConverter {
                     month: this.GREGORIAN_EPOCH_MONTH,
                     day: this.GREGORIAN_EPOCH_DAY
                 },
+                epochGregorianDate: "1970-01-01", // Critical: Unix epoch anchor
                 leapYearRules: [
                     {
                         type: 'divisible',

--- a/src/utils/CalendarMarkers.ts
+++ b/src/utils/CalendarMarkers.ts
@@ -361,6 +361,7 @@ export class CalendarMarkers {
                 { name: 'December', days: 31 }
             ],
             referenceDate: { year: 1970, month: 1, day: 1 },
+            epochGregorianDate: "1970-01-01", // Critical: Unix epoch anchor
             hoursPerDay: 24,
             minutesPerHour: 60,
             secondsPerMinute: 60

--- a/src/utils/CustomTimeAxis.ts
+++ b/src/utils/CustomTimeAxis.ts
@@ -423,6 +423,7 @@ export class CustomTimeAxis {
                 { name: 'December', days: 31 }
             ],
             referenceDate: { year: 1970, month: 1, day: 1 },
+            epochGregorianDate: "1970-01-01", // Critical: Unix epoch anchor
             hoursPerDay: 24,
             minutesPerHour: 60,
             secondsPerMinute: 60


### PR DESCRIPTION
Fixes data conversion issues for custom calendar timeline months/weeks.

Root Cause:
The getGregorianCalendar() method created Gregorian calendar objects without the critical epochGregorianDate field. When converting custom calendar dates to Gregorian for timeline axis positioning, the missing field caused the conversion to fall back to approximations, resulting in incorrect month and week calculations.

Changes:
- Add epochGregorianDate: "1970-01-01" to CustomTimeAxis.getGregorianCalendar()
- Add epochGregorianDate: "1970-01-01" to CalendarMarkers.getGregorianCalendar()
- Add epochGregorianDate: "1970-01-01" to CalendarConverter.convertCustomToGregorian()

Impact:
Custom calendar timelines now correctly display:
- ✅ Years (was already working)
- ✅ Months (now fixed)
- ✅ Weeks/Days (now fixed)

Follows Calendarium plugin approach of using epoch anchors for accurate date conversions between calendar systems.