### PR TITLE
Fix bugs in character network code

### DIFF
--- a/src/modals/NetworkGraphModal.ts
+++ b/src/modals/NetworkGraphModal.ts
@@ -732,15 +732,18 @@ export class NetworkGraphModal extends ResponsiveModal {
 	private updateStatusBar(): void {
 		if (!this.statusBarEl) return;
 
-		// For now, display a basic status message
-		// TODO: Enhance NetworkGraphRenderer to expose graph stats
+		const nodeCount = this.graphRenderer?.getNodeCount() || 0;
+		const edgeCount = this.graphRenderer?.getEdgeCount() || 0;
 		const activeFilters = Object.keys(this.currentFilters).length;
-		
+
 		let statusText = '';
-		if (activeFilters > 0) {
-			statusText = `${t('filteredLabel')} (${activeFilters} ${activeFilters === 1 ? 'filter' : 'filters'} active)`;
+		if (nodeCount === 0 && edgeCount === 0) {
+			statusText = t('emptyGraphMessage') || 'No entities to display';
 		} else {
-			statusText = t('nodesLabel') + ' & ' + t('edgesLabel');
+			statusText = `${nodeCount} ${nodeCount === 1 ? 'node' : 'nodes'} • ${edgeCount} ${edgeCount === 1 ? 'edge' : 'edges'}`;
+			if (activeFilters > 0) {
+				statusText += ` (${activeFilters} ${activeFilters === 1 ? 'filter' : 'filters'} active)`;
+			}
 		}
 
 		this.statusBarEl.textContent = statusText;


### PR DESCRIPTION
## Fixed Issues

### 1. Missing degree data on initial graph load (High Priority)
- **Problem**: Nodes were created without connection count (degree) data during initial load in `initializeCytoscape()`. This caused:
  - All nodes to appear the same size regardless of connections
  - Hub nodes (10+ connections) to not get their gold borders
  - Visual hierarchy styling to be completely broken until manual refresh
- **Fix**: Calculate and set degree data for all nodes before creating the Cytoscape instance (NetworkGraphRenderer.ts:242-259)

### 2. Modal status bar showed no data (Medium Priority)
- **Problem**: `updateStatusBar()` only displayed filter counts, not actual node/edge statistics, despite the getter methods existing
- **Fix**: Call `getNodeCount()` and `getEdgeCount()` to display real graph metrics with proper pluralization (NetworkGraphModal.ts:732-750)

### 3. Viewport save timeout memory leak (Medium Priority)
- **Problem**: `saveViewportTimeout` was set in `saveViewportState()` but never cleared in `destroy()`, causing timeout to fire after component destruction
- **Fix**: Clear timeout in destroy method (NetworkGraphRenderer.ts:1586-1590)

### 4. Legend panel memory leak (Low Priority)
- **Problem**: Legend panel elements weren't explicitly cleaned up in `destroy()`
- **Fix**: Added explicit cleanup for `legendPanelEl` and `legendToggleButtonEl` (NetworkGraphRenderer.ts:1598-1607)

## Impact
- Visual hierarchy now works correctly on initial load
- Status bar provides useful information to users
- Prevents memory leaks when graphs are destroyed
- Cleaner resource management

## Files Modified
- src/views/NetworkGraphRenderer.ts
- src/modals/NetworkGraphModal.ts