### PR TITLE
Add option to hide sidebar tabs

### DIFF
--- a/src/StorytellerSuiteSettingTab.ts
+++ b/src/StorytellerSuiteSettingTab.ts
@@ -40,6 +40,60 @@ export class StorytellerSuiteSettingTab extends PluginSettingTab {
                     });
             });
 
+        // --- Dashboard Tab Visibility ---
+        new Setting(containerEl)
+            .setName('Dashboard Tab Visibility')
+            .setHeading();
+
+        new Setting(containerEl)
+            .setDesc('Choose which tabs to show in the dashboard sidebar. Hidden tabs will not appear in the tab bar.');
+
+        // Define all available tabs with their display names
+        const availableTabs = [
+            { id: 'characters', name: 'Characters' },
+            { id: 'locations', name: 'Locations' },
+            { id: 'events', name: 'Timeline/Events' },
+            { id: 'items', name: 'Plot Items' },
+            { id: 'network', name: 'Network Graph' },
+            { id: 'gallery', name: 'Gallery' },
+            { id: 'groups', name: 'Groups' },
+            { id: 'references', name: 'References' },
+            { id: 'chapters', name: 'Chapters' },
+            { id: 'scenes', name: 'Scenes' },
+            { id: 'cultures', name: 'Cultures' },
+            { id: 'economies', name: 'Economies' },
+            { id: 'magicsystems', name: 'Magic Systems' }
+        ];
+
+        // Create a toggle for each tab
+        availableTabs.forEach(tab => {
+            const hiddenTabs = this.plugin.settings.hiddenDashboardTabs || [];
+            const isVisible = !hiddenTabs.includes(tab.id);
+
+            new Setting(containerEl)
+                .setName(tab.name)
+                .addToggle(toggle => toggle
+                    .setValue(isVisible)
+                    .setTooltip(isVisible ? 'Tab is visible' : 'Tab is hidden')
+                    .onChange(async (value) => {
+                        const hidden = this.plugin.settings.hiddenDashboardTabs || [];
+
+                        if (value) {
+                            // Show tab - remove from hidden list
+                            this.plugin.settings.hiddenDashboardTabs = hidden.filter(id => id !== tab.id);
+                        } else {
+                            // Hide tab - add to hidden list
+                            if (!hidden.includes(tab.id)) {
+                                this.plugin.settings.hiddenDashboardTabs = [...hidden, tab.id];
+                            }
+                        }
+
+                        await this.plugin.saveSettings();
+                        new Notice(`${tab.name} tab ${value ? 'shown' : 'hidden'}. Refresh the dashboard to see changes.`);
+                    })
+                );
+        });
+
         // --- Story Management Section ---
         new Setting(containerEl)
             .setName(t('stories'))

--- a/src/main.ts
+++ b/src/main.ts
@@ -151,6 +151,9 @@ import { getTemplateSections } from './utils/EntityTemplates';
     /** Sensory Profiles */
     enableSensoryProfiles?: boolean;
     sensoryProfiles?: LocationSensoryProfile[];
+
+    /** Dashboard tab visibility - array of tab IDs to hide */
+    hiddenDashboardTabs?: string[];
 }
 
 /**
@@ -200,7 +203,8 @@ import { getTemplateSections } from './utils/EntityTemplates';
     writingSessions: [],
     trackWritingSessions: false,
     enableWorldBuilding: true,
-    enableSensoryProfiles: true
+    enableSensoryProfiles: true,
+    hiddenDashboardTabs: []
 }
 
 /**

--- a/src/views/DashboardView.ts
+++ b/src/views/DashboardView.ts
@@ -477,8 +477,10 @@ export class DashboardView extends ItemView {
         this.tabContentContainer.style.overflowX = 'hidden';
         this.tabContentContainer.style.height = 'auto'; // Allow content to expand
 
-        // Initial active state
-        this.setActiveTab(this.activeTabId || this.tabs[0].id);
+        // Initial active state - use first visible tab if current tab is hidden
+        const visibleTabs = this.getVisibleTabs();
+        const initialTabId = visibleTabs.find(t => t.id === this.activeTabId)?.id || visibleTabs[0]?.id || this.tabs[0].id;
+        this.setActiveTab(initialTabId);
 
         // --- Register Vault Event Listeners for Auto-refresh ---
         this.registerVaultEventListeners();
@@ -542,6 +544,14 @@ export class DashboardView extends ItemView {
         return 'normal';
     }
 
+    /**
+     * Get visible tabs (excluding hidden tabs based on user settings)
+     */
+    private getVisibleTabs() {
+        const hiddenTabs = this.plugin.settings.hiddenDashboardTabs || [];
+        return this.tabs.filter(tab => !hiddenTabs.includes(tab.id));
+    }
+
     /** Render or re-render tabs according to available width (priority+ ribbon) */
     private layoutTabs(): void {
         if (!this.tabHeaderContainer || !this.tabHeaderRibbonEl) return;
@@ -559,8 +569,9 @@ export class DashboardView extends ItemView {
         // Tiny: still render tabs; they'll wrap to multiple lines
         // Compact mode reduces padding via mode pass-through
 
-        // Render all tabs and allow natural wrapping to any number of rows
-        for (const tab of this.tabs) {
+        // Render visible tabs only and allow natural wrapping to any number of rows
+        const visibleTabs = this.getVisibleTabs();
+        for (const tab of visibleTabs) {
             const btn = this.createTabButtonEl(tab, btnMode, false);
             this.tabHeaderRibbonEl.appendChild(btn);
         }


### PR DESCRIPTION
- Add hiddenDashboardTabs setting to StorytellerSuiteSettings interface
- Add default empty array to DEFAULT_SETTINGS (all tabs visible by default)
- Implement getVisibleTabs() method in DashboardView to filter hidden tabs
- Update layoutTabs() to only render visible tabs
- Update initial tab selection to use first visible tab if current is hidden
- Add Dashboard Tab Visibility section in settings with toggle for each tab
- Users can now hide unused tabs to reduce clutter in the sidebar