### PR TITLE
Fix missing templateStorageManager property errors

### DIFF
--- a/src/modals/CreateTemplateFromEntityModal.ts
+++ b/src/modals/CreateTemplateFromEntityModal.ts
@@ -228,10 +228,10 @@ export class CreateTemplateFromEntityModal extends ResponsiveModal {
             );
 
             // Auto-populate entity types
-            this.plugin.templateStorageManager.autoPopulateEntityTypes(template);
+            this.plugin.templateManager.autoPopulateEntityTypes(template);
 
             // Save template
-            await this.plugin.templateStorageManager.saveTemplate(template);
+            await this.plugin.templateManager.saveTemplate(template);
 
             // Call onSubmit callback
             this.onSubmit(template);

--- a/src/modals/TemplateEditorModal.ts
+++ b/src/modals/TemplateEditorModal.ts
@@ -202,7 +202,7 @@ export class TemplateEditorModal extends ResponsiveModal {
             }
 
             // Save template
-            await this.plugin.templateStorageManager.saveTemplate(template);
+            await this.plugin.templateManager.saveTemplate(template);
 
             // Call onSubmit callback
             this.onSubmit(template);

--- a/src/modals/TemplateLibraryModal.ts
+++ b/src/modals/TemplateLibraryModal.ts
@@ -44,7 +44,7 @@ export class TemplateLibraryModal extends ResponsiveModal {
     }
 
     private refreshTemplates(): void {
-        this.templates = this.plugin.templateStorageManager.getFilteredTemplates(this.filter);
+        this.templates = this.plugin.templateManager.getFilteredTemplates(this.filter);
     }
 
     private displayContent(): void {
@@ -274,7 +274,7 @@ export class TemplateLibraryModal extends ResponsiveModal {
         const confirmed = await this.confirmDelete(template.name);
         if (confirmed) {
             try {
-                await this.plugin.templateStorageManager.deleteTemplate(template.id);
+                await this.plugin.templateManager.deleteTemplate(template.id);
                 this.refreshAndDisplay();
             } catch (error) {
                 console.error('Error deleting template:', error);
@@ -286,7 +286,7 @@ export class TemplateLibraryModal extends ResponsiveModal {
     private async handleDuplicateTemplate(template: Template): Promise<void> {
         try {
             const newName = `${template.name} (Copy)`;
-            const duplicate = await this.plugin.templateStorageManager.copyTemplate(
+            const duplicate = await this.plugin.templateManager.copyTemplate(
                 template.id,
                 newName
             );

--- a/src/modals/TemplatePickerModal.ts
+++ b/src/modals/TemplatePickerModal.ts
@@ -32,13 +32,13 @@ export class TemplatePickerModal extends SuggestModal<Template> {
 
     getSuggestions(query: string): Template[] {
         const allTemplates = this.entityType
-            ? this.plugin.templateStorageManager.getTemplatesByEntityType(this.entityType)
-            : this.plugin.templateStorageManager.getAllTemplates();
+            ? this.plugin.templateManager.getTemplatesByEntityType(this.entityType)
+            : this.plugin.templateManager.getAllTemplates();
 
         if (!query) {
             // If no query, show recently used and popular templates
-            const recentTemplates = this.plugin.templateStorageManager.getRecentlyUsedTemplates(3);
-            const popularTemplates = this.plugin.templateStorageManager.getMostPopularTemplates(3);
+            const recentTemplates = this.plugin.templateManager.getRecentlyUsedTemplates(3);
+            const popularTemplates = this.plugin.templateManager.getMostPopularTemplates(3);
 
             // Combine and deduplicate
             const combined = [...recentTemplates];


### PR DESCRIPTION
…nager

Fixed TypeScript errors where modal files were referencing this.plugin.templateStorageManager when the actual property name in main.ts is templateManager.

Changes:
- CreateTemplateFromEntityModal.ts: Updated 2 references
- TemplateEditorModal.ts: Updated 1 reference
- TemplateLibraryModal.ts: Updated 3 references
- TemplatePickerModal.ts: Updated 4 references

All 10 TypeScript compilation errors now resolved.