### PR TITLE
Fix network graph undefined property error

### DIFF
--- a/src/views/DashboardView.ts
+++ b/src/views/DashboardView.ts
@@ -928,21 +928,16 @@ export class DashboardView extends ItemView {
     async renderNetworkContent(container: HTMLElement) {
         // Import NetworkGraphRenderer dynamically
         const { NetworkGraphRenderer } = await import('./NetworkGraphRenderer');
-        
-        // If graph already exists and is initialized, just refresh the data
-        if (this.networkGraphRenderer && this.networkGraphRenderer.cy) {
-            try {
-                await this.networkGraphRenderer.refresh();
-                return;
-            } catch (error) {
-                console.error('Error refreshing network graph, recreating:', error);
-                // If refresh fails, destroy and recreate
-                this.networkGraphRenderer.destroy();
-                this.networkGraphRenderer = null;
-            }
+
+        // Always clear and recreate - the container changes on each tab switch
+        // The old approach of trying to refresh the existing renderer fails because
+        // the container element is recreated by the tab system
+        if (this.networkGraphRenderer) {
+            this.networkGraphRenderer.destroy();
+            this.networkGraphRenderer = null;
         }
-        
-        // Clear container only when creating new graph
+
+        // Clear container before creating new graph
         container.empty();
         
         // Create controls container (search, zoom, layout)


### PR DESCRIPTION
This commit fixes three critical issues with the network graph:

1. Network Graph Refresh Error
   - Fixed "Cannot read properties of undefined (reading 'w')" error
   - Added container validation in refresh() method to ensure the canvas element is attached to DOM and has valid dimensions
   - Added cy.resize() call before running layout to sync container dimensions
   - Updated DashboardView to always recreate the graph renderer when switching tabs, since the container element changes

2. Invalid Font-Family Style Property
   - Enhanced getCSSVariable() to sanitize font-family values
   - Removes invalid '??' characters from Obsidian's CSS variables
   - Cleans up malformed font stacks (double commas, leading/trailing commas)
   - Falls back to 'sans-serif' if the cleaned value is invalid

3. Invalid Border-Color Style Property
   - Added detection for calc() expressions in color values
   - Falls back to default color when HSL/RGB contains calc() functions
   - Cytoscape doesn't support complex CSS calc() expressions

Files modified:
- src/views/NetworkGraphRenderer.ts: Enhanced validation and CSS sanitization
- src/views/DashboardView.ts: Fixed graph recreation logic

These changes ensure stable network graph rendering across tab switches and eliminate console warnings about invalid CSS properties.