### PR TITLE
Fix storyteller-suite plugin height validation errors

### DIFF
--- a/src/utils/TimelineRenderer.ts
+++ b/src/utils/TimelineRenderer.ts
@@ -467,7 +467,7 @@ export class TimelineRenderer {
                 verticalScroll: false,
                 horizontalScroll: true,
                 // Configure time axis to ensure proper rendering
-                height: this.options.ganttMode ? 'auto' : undefined
+                ...(this.options.ganttMode ? { height: 'auto' } : {})
             };
 
             // Set container overflow to allow proper scrolling


### PR DESCRIPTION
- Fix vis-timeline height validation error by only including height option when in Gantt mode (spreads empty object otherwise)
- Fix "Folder already exists" error by catching race condition when multiple ensureFolder calls create the same folder simultaneously