### PR TITLE
Fix milestone styling in gantt and timeline views

### DIFF
--- a/src/utils/TimelineRenderer.ts
+++ b/src/utils/TimelineRenderer.ts
@@ -803,7 +803,7 @@ export class TimelineRenderer {
             const classes: string[] = [];
             if (approx) classes.push('is-approx');
             if (isMilestone) classes.push('timeline-milestone');
-            if (this.options.ganttMode && !isMilestone) classes.push('gantt-bar');
+            if (this.options.ganttMode) classes.push('gantt-bar');
             if (isFlashback) classes.push('narrative-flashback');
             if (isFlashforward) classes.push('narrative-flashforward');
             

--- a/styles.css
+++ b/styles.css
@@ -3807,6 +3807,12 @@ body.mod-rtl .storyteller-group-members {
   overflow: hidden !important;
 }
 
+/* Gantt milestone bars have thicker borders to match modal styling */
+.storyteller-timeline-view .vis-item.gantt-bar.timeline-milestone {
+  border-width: 4px;
+  min-height: 36px;
+}
+
 /* Timeline View Gantt Swimlanes */
 .storyteller-timeline-view .vis-group:nth-child(even) {
   background: var(--background-secondary-alt);


### PR DESCRIPTION
Milestones were explicitly excluded from getting the gantt-bar class in gantt mode, which prevented CSS rules like .gantt-bar.timeline-milestone from applying. This caused milestones to miss the 4px border styling that regular gantt bars received.

- Remove !isMilestone condition so milestones get gantt-bar class
- Add matching CSS rule for timeline view milestone gantt bars