### PR TITLE
Fix timeline zoom to follow scroll position

### DIFF
--- a/src/utils/TimelineRenderer.ts
+++ b/src/utils/TimelineRenderer.ts
@@ -50,7 +50,8 @@ export class TimelineRenderer {
     private timeline: any = null;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private dependencyArrows: any = null;
-    
+    private wheelHandler: ((e: WheelEvent) => void) | null = null;
+
     // Configuration
     private options: TimelineRendererOptions;
     private filters: TimelineFilters = {};
@@ -274,6 +275,11 @@ export class TimelineRenderer {
      * Destroy timeline and clean up
      */
     destroy(): void {
+        // Remove wheel handler
+        if (this.wheelHandler) {
+            this.container.removeEventListener('wheel', this.wheelHandler);
+            this.wheelHandler = null;
+        }
         if (this.dependencyArrows) {
             try {
                 this.dependencyArrows.removeArrows();
@@ -317,7 +323,7 @@ export class TimelineRenderer {
                 stack: this.options.stackEnabled,
                 stackSubgroups: true,
                 margin: { item: itemMargin, axis: 20 },
-                zoomable: true,
+                zoomable: false, // Disable default zoom - we handle it with custom cursor-centered zoom
                 zoomMin: dayMs,
                 zoomMax: 1000 * yearMs,
                 multiselect: true,
@@ -425,6 +431,50 @@ export class TimelineRenderer {
                     }).open();
                 }
             });
+
+            // Custom wheel handler for cursor-centered zoom
+            // This ensures zooming focuses on where the mouse is positioned
+            const zoomMin = dayMs;
+            const zoomMax = 1000 * yearMs;
+
+            this.wheelHandler = (e: WheelEvent) => {
+                if (!this.timeline) return;
+
+                e.preventDefault();
+                e.stopPropagation();
+
+                // Get current visible range
+                const currentWindow = this.timeline.getWindow();
+                const currentStart = currentWindow.start.getTime();
+                const currentEnd = currentWindow.end.getTime();
+                const currentRange = currentEnd - currentStart;
+
+                // Calculate zoom factor based on scroll direction
+                // Positive deltaY = scroll down = zoom out, Negative deltaY = scroll up = zoom in
+                const zoomFactor = e.deltaY > 0 ? 1.2 : 1 / 1.2;
+
+                // Calculate new range with zoom limits
+                let newRange = currentRange * zoomFactor;
+                newRange = Math.max(zoomMin, Math.min(zoomMax, newRange));
+
+                // Get cursor position relative to the timeline container
+                const rect = this.container.getBoundingClientRect();
+                const cursorX = e.clientX - rect.left;
+                const containerWidth = rect.width;
+
+                // Calculate the time position under the cursor
+                const cursorRatio = cursorX / containerWidth;
+                const cursorTime = currentStart + cursorRatio * currentRange;
+
+                // Calculate new window keeping cursor position fixed
+                const newStart = cursorTime - cursorRatio * newRange;
+                const newEnd = cursorTime + (1 - cursorRatio) * newRange;
+
+                // Apply the new window
+                this.timeline.setWindow(new Date(newStart), new Date(newEnd), { animation: false });
+            };
+
+            this.container.addEventListener('wheel', this.wheelHandler, { passive: false });
 
             // Render dependency arrows in Gantt mode
             if (this.options.ganttMode && this.options.showDependencies) {


### PR DESCRIPTION
When scrolling on the timeline, zoom now centers on the mouse cursor position instead of zooming to a random point. This provides a more intuitive zoom experience where users can zoom into specific events by positioning their cursor over them.

- Disabled default vis-timeline zoom behavior
- Added custom wheel event handler with cursor position tracking
- Calculates zoom window to keep cursor time position fixed
- Properly cleans up event listener on timeline destroy