### PR TITLE
Fix network graph navigation delay issue

### DIFF
--- a/src/views/NetworkGraphRenderer.ts
+++ b/src/views/NetworkGraphRenderer.ts
@@ -683,6 +683,9 @@ export class NetworkGraphRenderer {
         this.cy.on('mouseover', 'node', (evt) => {
             const node = evt.target;
 
+            // Clear all old highlights immediately to prevent stale highlights when moving quickly between nodes
+            this.cy?.elements().removeClass('highlighted dimmed');
+
             // Get all neighbors of the hovered node (nodes connected to it)
             const neighbors = node.neighborhood('node');
 


### PR DESCRIPTION
Resolves issue where rapidly moving between nodes would leave multiple nodes highlighted. The mouseout timeout (500ms) to clear highlights was being cancelled by mouseover on the new node, preventing old highlights from being removed.

Now immediately clears all highlights at the start of mouseover before applying new ones, ensuring only the current node is highlighted.